### PR TITLE
Feature/promise reject on error

### DIFF
--- a/src/modbus-client-core.js
+++ b/src/modbus-client-core.js
@@ -91,7 +91,9 @@ module.exports = stampit()
         clearTimeout(currentRequest.timeout)
       }
       this.log.debug('Cleaning up request fifo.')
-      this.reqFifo = []
+      while (this.reqFifo.length) {
+        this.reqFifo.shift().defer.reject({err: 'Fifo cleanup'})
+      }
     }.bind(this)
 
     let handleErrorPDU = function (pdu) {

--- a/src/modbus-client-core.js
+++ b/src/modbus-client-core.js
@@ -181,6 +181,7 @@ module.exports = stampit()
         if (this.inState('closed')) {
           this.emit('error', 'connection closed')
         }
+        defer.reject({err: 'modbus client not in "ready" state'})
       }
     }
 

--- a/src/modbus-tcp-client.js
+++ b/src/modbus-tcp-client.js
@@ -64,8 +64,8 @@ module.exports = stampit()
     }.bind(this)
 
     let onSocketConnect = function () {
-      this.emit('connect')
       this.setState('ready')
+      this.emit('connect')
     }.bind(this)
 
     let onSocketClose = function (hadErrors) {


### PR DESCRIPTION
The motivation for this PR is to make sure all unsuccessful promises get rejected, and never lost in the void in case of errors. For code consuming this library, having rejected promises is needed to implement logic for conducting execution and retries of commands.

Also, setting the state to ready before emitting 'connect' enables firing commands on connect, without getting rejected since state needs to be 'ready' to execute.