### PR TITLE
Fix Modbus client socket timeout

### DIFF
--- a/src/modbus-tcp-client.js
+++ b/src/modbus-tcp-client.js
@@ -92,13 +92,12 @@ module.exports = stampit()
       this.emit('error', err)
     }.bind(this)
 
-    let onSocketTimeout = function (err) {
+    let onSocketTimeout = function () {
       this.logError('Socket Timeout, setting state to error')
 
       this.setState('error')
       this.emit('error', 'timeout')
     }.bind(this)
-
 
     let onSocketData = function (data) {
       this.log.debug('received data')

--- a/src/modbus-tcp-client.js
+++ b/src/modbus-tcp-client.js
@@ -54,6 +54,7 @@ module.exports = stampit()
         socket.on('close', onSocketClose)
         socket.on('error', onSocketError)
         socket.on('data', onSocketData)
+        socket.on('timeout', onSocketTimeout)
       }
 
       try {
@@ -90,6 +91,14 @@ module.exports = stampit()
       this.setState('error')
       this.emit('error', err)
     }.bind(this)
+
+    let onSocketTimeout = function (err) {
+      this.logError('Socket Timeout, setting state to error')
+
+      this.setState('error')
+      this.emit('error', 'timeout')
+    }.bind(this)
+
 
     let onSocketData = function (data) {
       this.log.debug('received data')


### PR DESCRIPTION
Socket timeout error is now caught and a 'timeout' error is emitted by modbus client instead of failing silently.
This fixes issue #5 